### PR TITLE
Add GitHub Actions workflow for Docker image builds

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,48 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build_backend:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build backend image
+        uses: docker/build-push-action@v4
+        with:
+          context: ./backend
+          file: ./backend/Dockerfile
+          push: false # Do not push the image yet
+          tags: backend-image:latest # Example tag
+
+  build_frontend:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build frontend image
+        uses: docker/build-push-action@v4
+        with:
+          context: ./frontend
+          file: ./frontend/Dockerfile
+          push: false # Do not push the image yet
+          tags: frontend-image:latest # Example tag


### PR DESCRIPTION
This commit introduces a new GitHub Actions workflow located at .github/workflows/docker-build.yml.

The workflow is configured to trigger on:
- Pushes to the 'main' branch
- Pull requests targeting the 'main' branch

It includes two jobs:
1. build_backend: Builds the Docker image for the backend service using backend/Dockerfile.
2. build_frontend: Builds the Docker image for the frontend service using frontend/Dockerfile.

Both jobs utilize actions/checkout@v3, docker/setup-qemu-action@v2, docker/setup-buildx-action@v2, and docker/build-push-action@v4. The built images are tagged (e.g., backend-image:latest) but are not pushed to any container registry in this initial setup.