### PR TITLE
 use short commit SHA for docker image tags

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -39,7 +39,7 @@ jobs:
           push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
           tags: | # Updated tags
             ghcr.io/${{ github.repository_owner }}/pgweb-backend:latest
-            ghcr.io/${{ github.repository_owner }}/pgweb-backend:${{ github.sha }}
+            ghcr.io/${{ github.repository_owner }}/pgweb-backend:{{.ShortSHA}}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -75,6 +75,6 @@ jobs:
           push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
           tags: | # Updated tags
             ghcr.io/${{ github.repository_owner }}/pgweb-frontend:latest
-            ghcr.io/${{ github.repository_owner }}/pgweb-frontend:${{ github.sha }}
+            ghcr.io/${{ github.repository_owner }}/pgweb-frontend:{{.ShortSHA}}
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
Updated the docker build workflow to use the `{{.ShortSHA}}` placeholder provided by `docker/build-push-action` for tagging images with the short commit hash. This applies to both backend and frontend images.