### PR TITLE
feat: Optimize main branch test workflow

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -16,11 +16,29 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
+      - name: Set IMAGE_TAG
+        run: echo "IMAGE_TAG=$(echo ${GITHUB_SHA::7})" >> $GITHUB_ENV
+
       - name: Set up Docker
         uses: docker/setup-buildx-action@v2
+
+      - name: Set image names for main branch push
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: |
+          echo "BACKEND_IMAGE=ghcr.io/${{ github.repository_owner }}/pgweb-backend:${{ env.IMAGE_TAG }}" >> $GITHUB_ENV
+          echo "FRONTEND_IMAGE=ghcr.io/${{ github.repository_owner }}/pgweb-frontend:${{ env.IMAGE_TAG }}" >> $GITHUB_ENV
+
+      - name: Pull images for main branch
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: |
+          docker pull ${{ env.BACKEND_IMAGE }}
+          docker pull ${{ env.FRONTEND_IMAGE }}
 
       - name: Set up Docker Compose
         run: sudo apt-get update && sudo apt-get install -y docker-compose
 
       - name: Run tests
+        env:
+          BACKEND_IMAGE: ${{ env.BACKEND_IMAGE }}
+          FRONTEND_IMAGE: ${{ env.FRONTEND_IMAGE }}
         run: docker-compose -f compose.test.yml up --exit-code-from cypress

--- a/compose.test.yml
+++ b/compose.test.yml
@@ -28,6 +28,7 @@ services:
         condition: service_healthy
 
   backend:
+    image: ${BACKEND_IMAGE:-pgweb/pgweb-backend-test}
     build:
       context: ./backend
       dockerfile: Dockerfile
@@ -57,6 +58,7 @@ services:
       start_period: 10s
 
   frontend:
+    image: ${FRONTEND_IMAGE:-pgweb/pgweb-frontend-test}
     build:
       context: ./frontend
       dockerfile: Dockerfile


### PR DESCRIPTION
Modify GitHub workflows to optimize testing on main branch pushes:

- Skip building images in the test workflow if pushing to main.
- Use recently built images tagged with the current short hash for tests on main.

Changes:
- `compose.test.yml`: Updated to use environment variables (`BACKEND_IMAGE`, `FRONTEND_IMAGE`) for specifying service images, with fallbacks to build locally if the variables are not set. This allows PRs to build images as before, while main branch workflows can use pre-built images.
- `.github/workflows/testing.yml`:
    - Added step to determine short commit SHA (`IMAGE_TAG`).
    - Added step to define `BACKEND_IMAGE` and `FRONTEND_IMAGE` env vars pointing to GHCR images tagged with `IMAGE_TAG` when on main branch.
    - Added step to explicitly pull these images on main branch pushes.
    - Updated `docker-compose up` command to pass `BACKEND_IMAGE` and `FRONTEND_IMAGE` environment variables, so it uses the correct images based on the workflow context (main push vs. PR).
- No changes were needed for `.github/workflows/docker-build.yml` as it already builds and pushes images to GHCR on main branch pushes, which are then consumed by the modified testing workflow.