### PR TITLE
Fix: Implement strict validation for database and usernames

### DIFF
--- a/backend/dbutils/provision.go
+++ b/backend/dbutils/provision.go
@@ -23,45 +23,26 @@ var (
 	passwordLength = 16
 )
 
-// sanitizeIdentifier cleans a string to be a safe PostgreSQL identifier.
+// sanitizeIdentifier validates a string to be a safe PostgreSQL identifier.
+// It checks if the name adheres to the pattern: starts with a lowercase letter,
+// followed by lowercase letters, numbers, or underscores, and is not longer
+// than 63 characters.
 func sanitizeIdentifier(name string) (string, error) {
-	name = strings.ToLower(name)
-	// Replace common problematic characters first
-	name = strings.ReplaceAll(name, "-", "_")
-	name = strings.ReplaceAll(name, " ", "_")
-
-	var sb strings.Builder
-	for _, r := range name {
-		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '_' {
-			sb.WriteRune(r)
-		}
-	}
-	name = sb.String()
-
-	if len(name) == 0 {
-		return "", fmt.Errorf("sanitized name is empty")
-	}
-	if !(name[0] >= 'a' && name[0] <= 'z') {
-		// If it doesn't start with a letter, prefix one. This is a simple fix.
-		// A better approach might be to reject or require user to fix.
-		name = "u_" + name
-	}
-
+	// Check length first. PostgreSQL identifiers are typically limited to 63 characters.
 	if len(name) > 63 {
-		name = name[:63]
-	}
-	name = strings.TrimRight(name, "_")
-	if len(name) == 0 { // Re-check after potential trim
-		return "", fmt.Errorf("sanitized name became empty after trimming trailing underscores")
-	}
-	if !(name[0] >= 'a' && name[0] <= 'z') { // Re-check start char
-		return "", fmt.Errorf("sanitized name '%s' does not start with a letter after processing", name)
+		return "", fmt.Errorf("identifier '%s' exceeds maximum length of 63 characters", name)
 	}
 
+	// Check if the name matches the required pattern.
+	// The pattern ^[a-z][a-z0-9_]*$ means:
+	// - ^[a-z]: Must start with a lowercase letter.
+	// - [a-z0-9_]*: Followed by zero or more lowercase letters, digits, or underscores.
+	// - $: End of string.
 	if !safeIdentifierPattern.MatchString(name) {
-		return "", fmt.Errorf("sanitized name '%s' does not match safe identifier pattern ^[a-z][a-z0-9_]*$", name)
+		return "", fmt.Errorf("identifier '%s' is invalid: must start with a lowercase letter and contain only lowercase letters, numbers, or underscores", name)
 	}
 
+	// If all checks pass, the name is considered valid and returned as is.
 	return name, nil
 }
 

--- a/backend/dbutils/provision_test.go
+++ b/backend/dbutils/provision_test.go
@@ -621,3 +621,63 @@ func TestExtensions(t *testing.T) {
 		t.Logf("Successfully used pgvector: %s", embedding)
 	})
 }
+
+func TestSanitizeIdentifier(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		want      string
+		expectErr bool
+		errSubstr string // Substring to check for in the error message
+	}{
+		// Valid cases
+		{"valid simple", "mydb", "mydb", false, ""},
+		{"valid with numbers", "mydb123", "mydb123", false, ""},
+		{"valid with underscores", "my_db_123", "my_db_123", false, ""},
+		{"valid single char", "a", "a", false, ""},
+		{"valid max length", strings.Repeat("a", 63), strings.Repeat("a", 63), false, ""},
+
+		// Invalid cases - pattern mismatch
+		{"invalid start with number", "1mydb", "", true, "must start with a lowercase letter"},
+		{"invalid start with underscore", "_mydb", "", true, "must start with a lowercase letter"},
+		{"invalid with uppercase", "MyDb", "", true, "contain only lowercase letters"},
+		{"invalid with hyphen", "my-db", "", true, "contain only lowercase letters"},
+		{"invalid with space", "my db", "", true, "contain only lowercase letters"},
+		{"invalid with special char", "mydb!", "", true, "contain only lowercase letters"},
+		{"invalid empty string", "", "", true, "must start with a lowercase letter"}, // or "invalid" depending on exact error
+
+		// Invalid cases - too long
+		{"invalid too long", strings.Repeat("a", 64), "", true, "exceeds maximum length"},
+
+		// Cases that would have been changed by old sanitizer but now error
+		{"old: leading number", "1database", "", true, "must start with a lowercase letter"},
+		{"old: uppercase", "UPPERCASEDB", "", true, "contain only lowercase letters"},
+		{"old: hyphens", "hyphen-db-name", "", true, "contain only lowercase letters"},
+		{"old: spaces", "db with spaces", "", true, "contain only lowercase letters"},
+		{"old: mixed issues", "1_My-Db!", "", true, "must start with a lowercase letter"}, // Error could be for start or chars
+		{"old: starts with underscore then fixed", "_fixed_db", "", true, "must start with a lowercase letter"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := sanitizeIdentifier(tt.input)
+			if tt.expectErr {
+				if err == nil {
+					t.Errorf("sanitizeIdentifier(%q) expected error, got nil", tt.input)
+					return
+				}
+				if tt.errSubstr != "" && !strings.Contains(err.Error(), tt.errSubstr) {
+					t.Errorf("sanitizeIdentifier(%q) error = %v, expected error containing %q", tt.input, err, tt.errSubstr)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("sanitizeIdentifier(%q) unexpected error: %v", tt.input, err)
+					return
+				}
+				if got != tt.want {
+					t.Errorf("sanitizeIdentifier(%q) = %q, want %q", tt.input, got, tt.want)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
The `sanitizeIdentifier` function in `backend/dbutils/provision.go` has been modified to act as a strict validator instead of a sanitizer/coercer.

It now enforces the following rules directly on the input string:
1. Must match the regex `^[a-z][a-z0-9_]*$`. This means it must start with a lowercase letter and contain only lowercase letters, numbers, and underscores.
2. Must not exceed 63 characters in length.

If the input fails these checks, an error is returned. The function no longer attempts to modify the input (e.g., by lowercasing, replacing characters, or prefixing `u_`).

Unit tests for `sanitizeIdentifier` have been added to `backend/dbutils/provision_test.go` to cover various valid and invalid scenarios under the new strict validation logic.

Existing functions calling `sanitizeIdentifier` already propagate errors correctly, so the stricter validation messages will now be surfaced to you.