### PR TITLE
fix(dbutils): serialize CREATE DATABASE to avoid template1 race

### DIFF
--- a/backend/dbutils/provision.go
+++ b/backend/dbutils/provision.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"regexp"
 	"strings"
+	"sync"
 	"time"
 
 	"pgweb-backend/models" // To use models.ManagedPGUser
@@ -21,6 +22,11 @@ var (
 	// Character set for password generation
 	passwordChars  = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%^&*"
 	passwordLength = 16
+	// PostgreSQL serializes CREATE DATABASE through template1; concurrent calls
+	// can fail with "source database template1 is being accessed by other users".
+	// Serialize in-process so a single app instance never issues two concurrent
+	// CREATE DATABASE statements.
+	createDatabaseMu sync.Mutex
 )
 
 // sanitizeIdentifier validates a string to be a safe PostgreSQL identifier.
@@ -102,6 +108,9 @@ func getSpecificDatabaseDSN(generalDSN, dbName string) string {
 
 // CreatePostgresDatabase creates a new database and enables pgvector extension.
 func CreatePostgresDatabase(pgAdminDSN, dbName string) error {
+	createDatabaseMu.Lock()
+	defer createDatabaseMu.Unlock()
+
 	log.Printf("Attempting to create database: %s", dbName)
 	safeDBName, err := sanitizeIdentifier(dbName)
 	if err != nil {

--- a/backend/dbutils/provision_test.go
+++ b/backend/dbutils/provision_test.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -708,6 +709,60 @@ func TestSanitizeIdentifier(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestCreatePostgresDatabase_ConcurrentDoesNotRace asserts that many concurrent
+// CreatePostgresDatabase calls all succeed. Postgres serializes CREATE DATABASE
+// through template1, so two concurrent calls within one process can fail with
+// "source database template1 is being accessed by other users". Without
+// in-process serialization this test is flaky; with the mutex it must always
+// pass.
+func TestCreatePostgresDatabase_ConcurrentDoesNotRace(t *testing.T) {
+	adminDSN := os.Getenv("PG_ADMIN_DSN")
+	if adminDSN == "" {
+		t.Skip("PG_ADMIN_DSN not set")
+	}
+
+	const n = 10
+	suffix := strings.ReplaceAll(uuid.New().String()[:8], "-", "")
+	names := make([]string, n)
+	for i := range names {
+		names[i] = fmt.Sprintf("racetest_%s_%d", suffix, i)
+	}
+
+	t.Cleanup(func() {
+		adminDB, err := connectToDB(adminDSN)
+		if err != nil {
+			t.Logf("cleanup: connect: %v", err)
+			return
+		}
+		defer adminDB.Close()
+		for _, name := range names {
+			if _, err := adminDB.Exec(fmt.Sprintf("DROP DATABASE IF EXISTS %s", name)); err != nil {
+				t.Logf("cleanup: drop %s: %v", name, err)
+			}
+		}
+	})
+
+	var wg sync.WaitGroup
+	errs := make([]error, n)
+	start := make(chan struct{})
+	for i, name := range names {
+		wg.Add(1)
+		go func(i int, name string) {
+			defer wg.Done()
+			<-start
+			errs[i] = CreatePostgresDatabase(adminDSN, name)
+		}(i, name)
+	}
+	close(start)
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Errorf("concurrent create #%d (%s) failed: %v", i, names[i], err)
+		}
 	}
 }
 


### PR DESCRIPTION
Postgres serializes CREATE DATABASE through template1, so two concurrent calls within one app instance can fail with "source database template1 is being accessed by other users". This surfaced as an intermittent 500 in the e2e test "should create a new database" when playwright ran with multiple workers and two specs hit POST /api/databases at the same moment.

Add an in-process sync.Mutex around CreatePostgresDatabase so a single app instance never issues two concurrent CREATE DATABASE statements. Tests in different workers can keep running in parallel; only the provisioning step itself is serialized.